### PR TITLE
Fix code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/templates/default/base.html
+++ b/templates/default/base.html
@@ -61,11 +61,24 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script>
         // Initialize highlight.js with line numbers
+        function escapeHTML(str) {
+            return str.replace(/[&<>"']/g, function (match) {
+                const escapeMap = {
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#39;'
+                };
+                return escapeMap[match];
+            });
+        }
+
         document.querySelectorAll('pre code').forEach((block) => {
             // Add line numbers
             const lines = block.textContent.split('\n');
             block.innerHTML = lines.map((line, index) => 
-                `<span class="line">${line}</span>`
+                `<span class="line">${escapeHTML(line)}</span>`
             ).join('\n');
             
             // Apply syntax highlighting


### PR DESCRIPTION
Fixes [https://github.com/imigueldiaz/zephyr-md/security/code-scanning/11](https://github.com/imigueldiaz/zephyr-md/security/code-scanning/11)

To fix this issue, we need to ensure that any text content extracted from the DOM and re-inserted as HTML is properly escaped to prevent XSS attacks. This can be achieved by using a function to escape HTML special characters before setting the `innerHTML`.

- We will create a function to escape HTML special characters.
- We will use this function to escape each line of text before setting it as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
