### PR TITLE
Potential fix for code scanning alert no. 36: Bad HTML filtering regexp

### DIFF
--- a/src/uploads/uploadController.ts
+++ b/src/uploads/uploadController.ts
@@ -43,19 +43,17 @@ export const validateMarkdownUpload = (req: Request, res: Response, next: NextFu
 };
 
 function validateContent(content: string): boolean {
-    // Check for potentially dangerous patterns
-    const dangerousPatterns = [
-        /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-        /javascript:/gi,
-        /data:/gi,
-        /vbscript:/gi,
-        /on\w+\s*=/gi,
-        /document\./gi,
-        /\$\{.*\}/g // Template literal injection
-    ];
+    // Sanitize content using sanitize-html
+    const sanitized = sanitizeHtml(content, {
+        allowedTags: [],
+        allowedAttributes: {},
+        disallowedTagsMode: 'discard',
+        enforceHtmlBoundary: true,
+        parseStyleAttributes: false
+    });
 
-    // Check if content contains any dangerous patterns
-    return !dangerousPatterns.some(pattern => pattern.test(content));
+    // Check if sanitized content is different from the original content
+    return sanitized === content;
 }
 
 function sanitizeContent(content: string): string {


### PR DESCRIPTION
Potential fix for [https://github.com/imigueldiaz/zephyr-md/security/code-scanning/36](https://github.com/imigueldiaz/zephyr-md/security/code-scanning/36)

To fix the problem, we should replace the custom regular expression with a well-tested sanitization library that can handle various edge cases and ensure that all potentially dangerous HTML tags and attributes are properly sanitized. This approach is more reliable and secure than trying to write custom regular expressions for HTML sanitization.

The best way to fix the problem without changing existing functionality is to use the `sanitize-html` library, which is already imported in the code. We will update the `validateContent` function to use this library for sanitizing the content and checking for dangerous patterns.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
