### PR TITLE
Potential fix for code scanning alert no. 30: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "markdown-it": "14.1.0",
     "marked": "^15.0.6",
     "multer": "1.4.5-lts.1",
-    "sanitize-html": "2.14.0"
+    "sanitize-html": "2.14.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",


### PR DESCRIPTION
Potential fix for [https://github.com/imigueldiaz/zephyr-md/security/code-scanning/30](https://github.com/imigueldiaz/zephyr-md/security/code-scanning/30)

The best way to fix the problem is to use a well-tested sanitization library instead of relying on custom regular expressions. Libraries like `DOMPurify` are designed to handle various edge cases and provide a more secure way to sanitize HTML content.

To implement the fix:
1. Install the `DOMPurify` library.
2. Replace the custom regular expression-based validation with `DOMPurify` to sanitize the file content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
